### PR TITLE
Send code coverage info to codecov, closes #10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,5 @@ jobs:
           cd ${{ github.workspace }}
           sccache --zero-stats
           cargo clippy
-          just test
+          just ci-test
           sccache --show-stats

--- a/Justfile
+++ b/Justfile
@@ -3,6 +3,12 @@
 _default:
 	just --list
 
+# Run all tests with nextest and cargo-llvm-cov
+ci-test:
+	#!/bin/bash -eux
+	cargo llvm-cov nextest --lcov --output-path coverage.lcov
+	codecov
+
 # Run all tests with cargo nextest
 test *args:
 	RUST_BACKTRACE=1 cargo nextest run {{args}}


### PR DESCRIPTION
This measures code coverage with `cargo-llvm-cov` and uploads it to codecov.