### PR TITLE
Supported chunked transfer-encoding

### DIFF
--- a/src/proto/errors.rs
+++ b/src/proto/errors.rs
@@ -2,16 +2,12 @@
 pub(crate) enum SemanticError {
     #[error("the headers are too long")]
     HeadersTooLong,
-
-    #[error("chunked transfer encoding is not supported")]
-    NoChunked,
 }
 
 impl SemanticError {
     pub(crate) fn as_http_response(&self) -> &'static [u8] {
         match self {
             Self::HeadersTooLong => b"HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n",
-            Self::NoChunked => b"HTTP/1.1 501 Chunked Transfer Encoding Not Implemented\r\n\r\n",
         }
     }
 }

--- a/src/proto/h1.rs
+++ b/src/proto/h1.rs
@@ -2,7 +2,6 @@
 //! is https://www.rfc-editor.org/rfc/rfc9110
 
 use eyre::Context;
-use nom::InputTake;
 use std::rc::Rc;
 use tokio_uring::net::TcpStream;
 use tracing::debug;

--- a/src/proto/h1.rs
+++ b/src/proto/h1.rs
@@ -2,6 +2,7 @@
 //! is https://www.rfc-editor.org/rfc/rfc9110
 
 use eyre::Context;
+use nom::InputTake;
 use std::rc::Rc;
 use tokio_uring::net::TcpStream;
 use tracing::debug;
@@ -46,15 +47,7 @@ pub async fn proxy(conn_dv: Rc<impl ConnectionDriver>, dos: TcpStream) -> eyre::
         };
         debug_print_req(&dos_req);
 
-        if dos_req.headers.is_chunked_transfer_encoding() {
-            let (res, _) = dos
-                .write_all(SemanticError::NoChunked.as_http_response())
-                .await;
-            res.wrap_err("writing error response downstream")?;
-
-            return Ok(());
-        }
-
+        let dos_chunked = dos_req.headers.is_chunked_transfer_encoding();
         let connection_close = dos_req.headers.is_connection_close();
         let dos_req_clen = dos_req.headers.content_len().unwrap_or_default();
 
@@ -100,14 +93,7 @@ pub async fn proxy(conn_dv: Rc<impl ConnectionDriver>, dos: TcpStream) -> eyre::
             };
         debug_print_res(&ups_res);
 
-        if ups_res.headers.is_chunked_transfer_encoding() {
-            let (res, _) = dos
-                .write_all(SemanticError::NoChunked.as_http_response())
-                .await;
-            res.wrap_err("writing error response downstream")?;
-
-            return Ok(());
-        }
+        let ups_chunked = ups_res.headers.is_chunked_transfer_encoding();
 
         // at this point, `dos_buf` has the start of the request body,
         // and `ups_buf` has the start of the response body
@@ -122,9 +108,20 @@ pub async fn proxy(conn_dv: Rc<impl ConnectionDriver>, dos: TcpStream) -> eyre::
             .wrap_err("writing response headers to downstream");
 
         // now let's proxy bodies!
-        let to_dos = copy(ups_buf, ups_res_clen, &ups, &dos);
-        let to_ups = copy(dos_buf, dos_req_clen, &dos, &ups);
-
+        let to_dos = async {
+            if ups_chunked {
+                copy_chunked(ups_buf, &ups, &dos).await
+            } else {
+                copy(ups_buf, ups_res_clen, &ups, &dos).await
+            }
+        };
+        let to_ups = async {
+            if dos_chunked {
+                copy_chunked(dos_buf, &dos, &ups).await
+            } else {
+                copy(dos_buf, dos_req_clen, &dos, &ups).await
+            }
+        };
         (dos_buf, ups_buf) = tokio::try_join!(to_dos, to_ups)?;
 
         if connection_close {
@@ -165,6 +162,47 @@ async fn copy(
         (res, slice) = src.read(buf.write_slice().limit(remain as _)).await;
         res?;
         buf = slice.into_inner();
+    }
+
+    Ok(buf)
+}
+
+async fn copy_chunked(mut buf: AggBuf, src: &TcpStream, dst: &TcpStream) -> eyre::Result<AggBuf> {
+    const MAX_CHUNK_LENGTH: u32 = 1024 * 1024;
+
+    loop {
+        debug!("reading chunk");
+        let chunk;
+
+        // TODO: this reads the whole chunk, but if we don't need to maintain
+        // chunk size, we don't need to buffer that far. we can just read
+        // whatever, skip the CRLF, know when we need to stop to read another
+        // chunk length, etc. this needs to be a state machine.
+        (buf, chunk) = match read_and_parse(h1::chunk, src, buf, MAX_CHUNK_LENGTH).await? {
+            Some(t) => t,
+            None => {
+                return Err(eyre::eyre!("peer went away before sending final chunk"));
+            }
+        };
+        debug!("read {} byte chunk", chunk.len);
+
+        if chunk.len == 0 {
+            debug!("received 0-length chunk, that's EOF!");
+            let mut list = IoChunkList::default();
+            list.push("0\r\n\r\n");
+            _ = write_all_list(dst, list).await?;
+
+            break;
+        }
+
+        {
+            let mut list = IoChunkList::default();
+            list.push(format!("{:x}\r\n", chunk.len).into_bytes());
+            list.push(chunk.data);
+            list.push("\r\n");
+
+            _ = write_all_list(dst, list).await?;
+        }
     }
 
     Ok(buf)

--- a/src/proto/util.rs
+++ b/src/proto/util.rs
@@ -19,33 +19,40 @@ where
     Parser: Fn(AggSlice) -> IResult<AggSlice, Output>,
 {
     loop {
-        if buf.write().capacity() >= max_len {
-            // XXX: not great that the error here is 'headers too long' when
-            // this is a generic parse function.
-            return Err(SemanticError::HeadersTooLong.into());
-        }
-        buf.write().grow_if_needed()?;
-
-        let (res, buf_s) = stream.read(buf.write_slice()).await;
-        let n = res.wrap_err("reading request headers from downstream")?;
-        buf = buf_s.into_inner();
-
-        if n == 0 {
-            if !buf.read().is_empty() {
-                return Err(eyre::eyre!("unexpected EOF"));
-            } else {
-                return Ok(None);
-            }
-        }
-
-        debug!("reading headers ({} bytes so far)", buf.read().len());
+        debug!("reading+parsing ({} bytes so far)", buf.read().len());
         let slice = buf.read().slice(0..buf.read().len());
 
         let (rest, req) = match parser(slice) {
             Ok(t) => t,
             Err(err) => {
                 if err.is_incomplete() {
-                    debug!("incomplete request, need more data");
+                    debug!(
+                        "incomplete request, need more data. start of buffer: {:?}",
+                        buf.read()
+                            .slice(0..std::cmp::min(buf.read().len(), 128))
+                            .to_string_lossy()
+                    );
+
+                    if buf.write().capacity() >= max_len {
+                        // XXX: not great that the error here is 'headers too long' when
+                        // this is a generic parse function.
+                        return Err(SemanticError::HeadersTooLong.into());
+                    }
+
+                    buf.write().grow_if_needed()?;
+
+                    let (res, buf_s) = stream.read(buf.write_slice()).await;
+                    let n = res.wrap_err("reading request headers from downstream")?;
+                    buf = buf_s.into_inner();
+
+                    if n == 0 {
+                        if !buf.read().is_empty() {
+                            return Err(eyre::eyre!("unexpected EOF"));
+                        } else {
+                            return Ok(None);
+                        }
+                    }
+
                     continue;
                 } else {
                     if let nom::Err::Error(e) = &err {

--- a/tests/helpers/sample_hyper_server.rs
+++ b/tests/helpers/sample_hyper_server.rs
@@ -8,6 +8,10 @@ use tracing::debug;
 
 pub(crate) struct TestService;
 
+pub fn big_body() -> String {
+    "this is a big chunk".repeat(256).repeat(128)
+}
+
 impl Service<Request<Body>> for TestService {
     type Response = Response<Body>;
     type Error = Infallible;


### PR DESCRIPTION
This needs a million tests still, and I'm not convinced we need to preserve the chunk size - even if we do, we probably don't need to buffer as much as we currently do.