### PR TITLE
Allow passing initial buffer, better errors, add missing grow_if_needed

### DIFF
--- a/src/bufpool/agg.rs
+++ b/src/bufpool/agg.rs
@@ -214,6 +214,12 @@ impl AggBuf {
 
         {
             let mut inner = self.inner.borrow_mut();
+            if inner.blocks.is_empty() {
+                panic!(
+                    "holding AggBuf wrong: please call grow_if_needed before calling write_slice"
+                );
+            }
+
             let (block_index, block_range) = inner.contiguous_range(inner.len..inner.capacity());
             ptr = unsafe {
                 inner.blocks[block_index]

--- a/src/proto/h1.rs
+++ b/src/proto/h1.rs
@@ -20,9 +20,11 @@ use crate::{
 const MAX_HEADER_LEN: u32 = 64 * 1024;
 
 /// Proxy incoming HTTP/1.1 requests to some upstream.
-pub async fn proxy(conn_dv: Rc<impl ConnectionDriver>, dos: TcpStream) -> eyre::Result<()> {
-    let mut dos_buf = AggBuf::default();
-
+pub async fn proxy(
+    conn_dv: Rc<impl ConnectionDriver>,
+    dos: TcpStream,
+    mut dos_buf: AggBuf,
+) -> eyre::Result<()> {
     loop {
         let dos_req;
         (dos_buf, dos_req) = match read_and_parse(h1::request, &dos, dos_buf, MAX_HEADER_LEN).await

--- a/src/proto/h1.rs
+++ b/src/proto/h1.rs
@@ -159,6 +159,8 @@ async fn copy(
             break;
         }
 
+        buf.write().grow_if_needed()?;
+
         let (res, slice);
         (res, slice) = src.read(buf.write_slice().limit(remain as _)).await;
         res?;

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -46,7 +46,7 @@ pub(crate) fn tcp_serve_h1_once(
     let proxy_fut = async move {
         let (stream, remote_addr) = ln.accept().await?;
         debug!("Accepted connection from {remote_addr}");
-        hring::proto::h1::proxy(conn_dv, stream).await?;
+        hring::proto::h1::proxy(conn_dv, stream, Default::default()).await?;
         debug!("Done serving h1 connection, initiating graceful shutdown");
         drop(tx);
         Ok(())


### PR DESCRIPTION
Passing an initial buffer is good not specifically for re-use, but for using streams from ktls, where rustls might've decoded some data already.