### PR TITLE
Introduce some test I/O types

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-10-21"
+channel = "nightly-2022-10-25"

--- a/src/io.rs
+++ b/src/io.rs
@@ -243,6 +243,13 @@ mod tests {
                 let n = res.unwrap();
                 assert_eq!(&buf[..n], b"read");
             }
+
+            {
+                let buf = vec![0u8; 0];
+                let (res, _) = cr.read(buf).await;
+                let n = res.unwrap();
+                assert_eq!(n, 0, "reached EOF");
+            }
         })
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,3 +1,6 @@
+use std::{cell::RefCell, rc::Rc};
+
+use tokio::sync::broadcast;
 use tokio_uring::{
     buf::{IoBuf, IoBufMut},
     net::TcpStream,
@@ -45,5 +48,92 @@ impl WriteOwned for TcpStream {
 
     async fn writev<B: IoBuf>(&self, list: Vec<B>) -> BufResult<usize, Vec<B>> {
         TcpStream::writev(self, list).await
+    }
+}
+
+pub struct ChanReadOwned {
+    tx: broadcast::Sender<()>,
+    buffered: Rc<RefCell<Buffered>>,
+}
+
+pub struct ChanReadOwnedSender {
+    tx: broadcast::Sender<()>,
+    buffered: Rc<RefCell<Buffered>>,
+}
+
+#[derive(Default)]
+struct Buffered {
+    pos: usize,
+    buf: Vec<u8>,
+}
+
+impl Buffered {
+    fn is_empty(&self) -> bool {
+        self.pos == self.buf.len()
+    }
+}
+
+impl ChanReadOwned {
+    pub fn new() -> (Self, ChanReadOwnedSender) {
+        let (tx, _) = broadcast::channel(1);
+        let buffered = Rc::new(RefCell::new(Default::default()));
+        (
+            Self {
+                tx: tx.clone(),
+                buffered: buffered.clone(),
+            },
+            ChanReadOwnedSender { tx, buffered },
+        )
+    }
+}
+
+impl ChanReadOwnedSender {
+    pub async fn send(&mut self, buf: Vec<u8>) {
+        loop {
+            {
+                let mut buffered = self.buffered.borrow_mut();
+                if buffered.is_empty() {
+                    buffered.pos = 0;
+                    buffered.buf = buf;
+                    _ = self.tx.send(());
+                    return;
+                }
+            }
+
+            let mut rx = self.tx.subscribe();
+            if rx.recv().await.is_ok() {
+                continue;
+            }
+        }
+    }
+}
+
+impl ReadOwned for ChanReadOwned {
+    async fn read<B: IoBufMut>(&self, mut buf: B) -> BufResult<usize, B> {
+        let out =
+            unsafe { std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total()) };
+
+        loop {
+            {
+                let mut current = self.buffered.borrow_mut();
+                let current = &mut current;
+                let remain = current.buf.len() - current.pos;
+
+                if remain > 0 {
+                    let n = std::cmp::min(remain, out.len());
+                    out[..n].copy_from_slice(&current.buf[current.pos..current.pos + n]);
+                    current.pos += n;
+
+                    _ = self.tx.send(());
+                    return (Ok(n), buf);
+                }
+            }
+
+            let mut rx = self.tx.subscribe();
+            match rx.recv().await {
+                Ok(_) => continue,
+                Err(_) => return (Ok(0), buf),
+            }
+        }
     }
 }

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -16,7 +16,7 @@ pub(crate) fn run(test: impl Future<Output = eyre::Result<()>>) {
         color_eyre::install().unwrap();
 
         if let Err(e) = test.await {
-            panic!("Error: {}", e);
+            panic!("Error: {e}");
         }
     });
 }


### PR DESCRIPTION
We don't necessarily want to establish TCP connections for every single protocol test.

Also we want to be able to trivially test that parses don't blow up when you feed them 1 byte at a time, that sort of thing.