### PR TITLE
Improve streamingness of body reading

### DIFF
--- a/src/bufpool/agg.rs
+++ b/src/bufpool/agg.rs
@@ -249,7 +249,7 @@ impl AggBuf {
     /// advance this buffer's offset. If this returns `None`, it means
     /// the filled portion is empty.
     pub fn take_contiguous_at_most(&mut self, n: u32) -> Option<Buf> {
-        let mut inner = self.inner.borrow_mut();
+        let inner = self.inner.borrow();
         if inner.len == 0 {
             return None;
         }
@@ -258,7 +258,7 @@ impl AggBuf {
         let len = std::cmp::min(n, inner.len);
         let end = start + len;
 
-        let (block_index, block_range) = inner.contiguous_range(start..len);
+        let (block_index, block_range) = inner.contiguous_range(start..end);
         let block = inner.blocks[block_index].dangerous_clone();
         let u16_block_range: Range<u16> =
             (block_range.start.try_into().unwrap())..(block_range.end.try_into().unwrap());
@@ -287,6 +287,8 @@ impl AggBuf {
                 len: inner.len - consumed,
             }
         };
+        drop(inner);
+
         *self = Self {
             inner: Rc::new(RefCell::new(next_inner)),
         };

--- a/src/bufpool/io_chunk.rs
+++ b/src/bufpool/io_chunk.rs
@@ -28,6 +28,16 @@ impl From<Buf> for IoChunk {
     }
 }
 
+impl AsRef<[u8]> for IoChunk {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            IoChunk::Static(slice) => slice,
+            IoChunk::Vec(vec) => vec.as_ref(),
+            IoChunk::Buf(buf) => buf.as_ref(),
+        }
+    }
+}
+
 impl IoChunk {
     #[inline(always)]
     pub fn as_io_buf(&self) -> &dyn IoBuf {

--- a/src/bufpool/io_chunk.rs
+++ b/src/bufpool/io_chunk.rs
@@ -156,6 +156,11 @@ impl IoChunkList {
         chunkable.append_to(&mut self.chunks);
     }
 
+    /// Add a single chunk to the list
+    pub fn push_chunk(&mut self, chunk: IoChunk) {
+        self.chunks.push(chunk);
+    }
+
     /// Returns total length
     pub fn len(&self) -> usize {
         self.chunks.iter().map(|c| c.len()).sum()

--- a/src/h1/body.rs
+++ b/src/h1/body.rs
@@ -1,20 +1,39 @@
 use std::{fmt, rc::Rc};
 
-use nom::InputTake;
 use tracing::debug;
 
 use crate::{
-    bufpool::{AggBuf, IoChunkList, IoChunkable},
+    bufpool::{AggBuf, IoChunkList},
     util::{read_and_parse, write_all_list},
-    Body, BodyChunk, ReadOwned, WriteOwned,
+    Body, BodyChunk, BodyError, BodyErrorReason, IoChunk, ReadOwned, WriteOwned,
 };
 
 pub(crate) struct H1Body<T> {
-    pub(crate) transport: Rc<T>,
-    pub(crate) buf: Option<AggBuf>,
-    pub(crate) kind: H1BodyKind,
-    pub(crate) read: u64,
-    pub(crate) eof: bool,
+    transport: Rc<T>,
+    buf: Option<AggBuf>,
+    state: H1BodyState,
+}
+
+#[derive(Debug)]
+enum H1BodyState {
+    Chunked(H1BodyChunkedState),
+    ContentLength(H1BodyContentLengthState),
+    Empty,
+}
+
+#[derive(Debug)]
+enum H1BodyChunkedState {
+    ReadingChunkHeader,
+    ReadingChunk { remain: u64 },
+
+    // We've gotten one empty chunk
+    Done,
+}
+
+#[derive(Debug)]
+struct H1BodyContentLengthState {
+    len: u64,
+    read: u64,
 }
 
 #[derive(Debug)]
@@ -27,114 +46,184 @@ pub(crate) enum H1BodyKind {
 impl<T> fmt::Debug for H1Body<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("H1Body")
-            .field("kind", &self.kind)
-            .field("read", &self.read)
-            .field("eof", &self.eof)
+            .field("state", &self.state)
             .finish()
     }
 }
 
-impl<T> Body for H1Body<T>
-where
-    T: ReadOwned,
-{
+impl<T: ReadOwned> H1Body<T> {
+    pub(crate) fn new(transport: Rc<T>, buf: AggBuf, kind: H1BodyKind) -> Self {
+        let state = match kind {
+            H1BodyKind::Chunked => H1BodyState::Chunked(H1BodyChunkedState::ReadingChunkHeader),
+            H1BodyKind::ContentLength(len) => {
+                H1BodyState::ContentLength(H1BodyContentLengthState { len, read: 0 })
+            }
+            H1BodyKind::Empty => H1BodyState::Empty,
+        };
+        H1Body {
+            transport,
+            buf: Some(buf),
+            state,
+        }
+    }
+}
+
+impl<T: ReadOwned> Body for H1Body<T> {
     fn content_len(&self) -> Option<u64> {
-        match self.kind {
-            H1BodyKind::Chunked => None,
-            H1BodyKind::ContentLength(len) => Some(len),
-            H1BodyKind::Empty => Some(0),
+        match self.state {
+            H1BodyState::Chunked(_) => None,
+            H1BodyState::ContentLength(state) => Some(state.len),
+            H1BodyState::Empty => Some(0),
         }
     }
 
     async fn next_chunk(&mut self) -> eyre::Result<BodyChunk> {
-        if self.eof {
-            return Ok(BodyChunk::Eof);
+        if self.buf.is_none() {
+            return Ok(BodyChunk::Done);
         }
 
-        match self.kind {
-            H1BodyKind::Chunked => {
-                const MAX_CHUNK_LENGTH: u32 = 1024 * 1024;
-
-                debug!("reading chunk");
-                let chunk;
-                let mut buf = self.buf.take().unwrap();
-                buf.write().grow_if_needed()?;
-
-                // TODO: this reads the whole chunk, but if we don't need to maintain
-                // chunk size, we don't need to buffer that far. we can just read
-                // whatever, skip the CRLF, know when we need to stop to read another
-                // chunk length, etc. this needs to be a state machine.
-                (buf, chunk) = match read_and_parse(
-                    super::parse::chunk,
-                    self.transport.as_ref(),
-                    buf,
-                    MAX_CHUNK_LENGTH,
-                )
-                .await?
-                {
-                    Some(t) => t,
-                    None => {
-                        return Err(eyre::eyre!("peer went away before sending final chunk"));
-                    }
-                };
-                debug!("read {} byte chunk", chunk.len);
-
-                self.buf = Some(buf);
-
-                if chunk.len == 0 {
-                    debug!("received 0-length chunk, that's EOF!");
-                    self.eof = true;
-                    Ok(BodyChunk::Eof)
-                } else {
-                    self.read += chunk.len;
-                    Ok(BodyChunk::AggSlice(chunk.data))
-                }
+        match &mut self.state {
+            H1BodyState::Chunked(state) => {
+                state
+                    .next_chunk(&mut self.buf, self.transport.as_ref())
+                    .await
             }
-            H1BodyKind::ContentLength(len) => {
-                let wanted = len - self.read;
-                if wanted == 0 {
-                    self.eof = true;
-                    return Ok(BodyChunk::Eof);
-                }
-
-                debug!(%wanted, "reading content-length body");
-                let mut buf = self.buf.take().unwrap();
-
-                let mut avail = buf.read().len();
-                if avail == 0 {
-                    buf.write().grow_if_needed()?;
-                    let mut slice = buf.write_slice().limit(wanted);
-
-                    let res;
-                    (res, slice) = self.transport.as_ref().read(slice).await;
-                    buf = slice.into_inner();
-                    let n = res?;
-                    debug!("read {n} bytes");
-                    avail += n as u32;
-                }
-                assert!(avail > 0);
-
-                let copied = std::cmp::min(wanted, avail as u64);
-                let slice = buf.read().read_slice();
-                let (suffix, prefix) = slice.take_split(copied as usize);
-                self.read += prefix.len() as u64;
-                let buf = buf.split_at(suffix);
-                self.buf = Some(buf);
-                Ok(BodyChunk::AggSlice(prefix))
+            H1BodyState::ContentLength(state) => {
+                state
+                    .next_chunk(&mut self.buf, self.transport.as_ref())
+                    .await
             }
-            H1BodyKind::Empty => {
-                self.eof = true;
-                Ok(BodyChunk::Eof)
+            H1BodyState::Empty => Ok(BodyChunk::Done),
+        }
+    }
+
+    fn eof(&self) -> bool {
+        match &self.state {
+            H1BodyState::Chunked(state) => state.eof(),
+            H1BodyState::ContentLength(state) => state.eof(),
+            H1BodyState::Empty => true,
+        }
+    }
+}
+
+impl H1BodyContentLengthState {
+    async fn next_chunk(
+        &mut self,
+        buf_slot: &mut Option<AggBuf>,
+        transport: &impl ReadOwned,
+    ) -> eyre::Result<BodyChunk> {
+        let remain = self.len - self.read;
+        if remain == 0 {
+            return Ok(BodyChunk::Done);
+        }
+
+        debug!(%remain, "reading content-length body");
+
+        let mut buf = buf_slot.take().unwrap();
+
+        if buf.read().len() == 0 {
+            buf.write().grow_if_needed()?;
+            let mut slice = buf.write_slice();
+            let res;
+            (res, slice) = transport.read(slice).await;
+            buf = slice.into_inner();
+            res.map_err(|e| BodyErrorReason::ErrorWhileReadingChunkData.with_cx(e))?;
+        }
+
+        // FIXME: integer demotion
+        let chunk = buf.take_contiguous_at_most(remain as u32);
+        match chunk {
+            Some(chunk) => {
+                self.read += chunk.len() as u64;
+                buf_slot.replace(buf);
+                return Ok(BodyChunk::Chunk(chunk.into()));
+            }
+            None => {
+                return Err(BodyErrorReason::ClosedWhileReadingContentLength
+                    .as_err()
+                    .into());
             }
         }
     }
 
     fn eof(&self) -> bool {
-        match self.kind {
-            H1BodyKind::Chunked => self.eof,
-            H1BodyKind::ContentLength(len) => self.read == len,
-            H1BodyKind::Empty => true,
+        match self {
+            H1BodyContentLengthState { len, read } => len == read,
         }
+    }
+}
+
+impl H1BodyChunkedState {
+    async fn next_chunk(
+        &mut self,
+        buf_slot: &mut Option<AggBuf>,
+        transport: &impl ReadOwned,
+    ) -> eyre::Result<BodyChunk> {
+        loop {
+            let mut buf = buf_slot.take().ok_or_else(|| BodyError {
+                reason: BodyErrorReason::CalledNextChunkAfterError,
+                context: None,
+            })?;
+
+            if let H1BodyChunkedState::Done = self {
+                buf_slot.replace(buf);
+                return Ok(BodyChunk::Done);
+            }
+
+            if let H1BodyChunkedState::ReadingChunkHeader = self {
+                let (next_buf, chunk_size) =
+                    read_and_parse(super::parse::chunk_size, transport, buf, 16)
+                        .await
+                        .map_err(|e| BodyErrorReason::InvalidChunkSize.with_cx(e))?
+                        .ok_or_else(|| BodyErrorReason::ClosedWhileReadingChunkSize.as_err())?;
+                buf = next_buf;
+                *self = H1BodyChunkedState::ReadingChunk { remain: chunk_size }
+            };
+
+            if let H1BodyChunkedState::ReadingChunk { remain } = self {
+                if *remain == 0 {
+                    // look for CRLF terminator
+                    let (next_buf, _) = read_and_parse(super::parse::crlf, transport, buf, 2)
+                        .await
+                        .map_err(|e| BodyErrorReason::InvalidChunkTerminator.with_cx(e))?
+                        .ok_or_else(|| {
+                            BodyErrorReason::ClosedWhileReadingChunkTerminator.as_err()
+                        })?;
+                    buf = next_buf;
+                    *self = H1BodyChunkedState::ReadingChunkHeader;
+                    buf_slot.replace(buf);
+                    continue;
+                }
+
+                if buf.read().len() == 0 {
+                    buf.write().grow_if_needed()?;
+                    let mut slice = buf.write_slice();
+                    let res;
+                    (res, slice) = transport.read(slice).await;
+                    buf = slice.into_inner();
+                    res.map_err(|e| BodyErrorReason::ErrorWhileReadingChunkData.with_cx(e))?;
+                }
+
+                // FIXME: integer demotion
+                let chunk = buf.take_contiguous_at_most(*remain as u32);
+                match chunk {
+                    Some(chunk) => {
+                        *remain -= chunk.len() as u64;
+                        buf_slot.replace(buf);
+                        return Ok(BodyChunk::Chunk(chunk.into()));
+                    }
+                    None => {
+                        return Err(BodyErrorReason::ClosedWhileReadingChunkData.as_err().into());
+                    }
+                }
+            } else {
+                unreachable!()
+            };
+        }
+    }
+
+    fn eof(&self) -> bool {
+        matches!(self, H1BodyChunkedState::Done)
     }
 }
 
@@ -151,11 +240,8 @@ pub(crate) async fn write_h1_body(
 ) -> eyre::Result<()> {
     loop {
         match body.next_chunk().await? {
-            BodyChunk::Buf(chunk) => write_h1_body_chunk(transport.as_ref(), chunk, mode).await?,
-            BodyChunk::AggSlice(chunk) => {
-                write_h1_body_chunk(transport.as_ref(), chunk, mode).await?
-            }
-            BodyChunk::Eof => {
+            BodyChunk::Chunk(chunk) => write_h1_body_chunk(transport.as_ref(), chunk, mode).await?,
+            BodyChunk::Done => {
                 // TODO: check that we've sent what we announced in terms of
                 // content length
                 write_h1_body_end(transport.as_ref(), mode).await?;
@@ -169,24 +255,22 @@ pub(crate) async fn write_h1_body(
 
 pub(crate) async fn write_h1_body_chunk(
     transport: &impl WriteOwned,
-    chunk: impl IoChunkable,
+    chunk: IoChunk,
     mode: BodyWriteMode,
 ) -> eyre::Result<()> {
     match mode {
         BodyWriteMode::Chunked => {
             let mut list = IoChunkList::default();
             list.push(format!("{:x}\r\n", chunk.len()).into_bytes());
-            list.push(chunk);
+            list.push_chunk(chunk);
             list.push("\r\n");
 
             let list = write_all_list(transport, list).await?;
             drop(list);
         }
         BodyWriteMode::ContentLength => {
-            let mut list = IoChunkList::default();
-            list.push(chunk);
-            let list = write_all_list(transport, list).await?;
-            drop(list);
+            let (res, _) = transport.write_all(chunk).await;
+            res?;
         }
     }
     Ok(())

--- a/src/h1/parse.rs
+++ b/src/h1/parse.rs
@@ -32,6 +32,16 @@ pub fn chunk(i: AggSlice) -> IResult<AggSlice, Chunk> {
     Ok((i, Chunk { len, data }))
 }
 
+/// Parses a chunked transfer coding chunk size (hex text followed by CRLF)
+pub fn chunk_size(i: AggSlice) -> IResult<AggSlice, u64> {
+    terminated(u64_text_hex, tag(CRLF))(i)
+}
+
+pub fn crlf(i: AggSlice) -> IResult<AggSlice, ()> {
+    let (i, _) = tag(CRLF)(i)?;
+    Ok((i, ()))
+}
+
 // Looks like `GET /path HTTP/1.1\r\n`, then headers
 pub fn request(i: AggSlice) -> IResult<AggSlice, Request> {
     let (i, method) = take_until_and_consume(b" ")(i)?;

--- a/src/h1/parse.rs
+++ b/src/h1/parse.rs
@@ -17,21 +17,6 @@ use crate::{
 
 const CRLF: &[u8] = b"\r\n";
 
-pub struct Chunk {
-    pub len: u64,
-    pub data: AggSlice,
-}
-
-/// Parses a single transfer-encoding chunk
-pub fn chunk(i: AggSlice) -> IResult<AggSlice, Chunk> {
-    let (i, len) = terminated(u64_text_hex, tag(CRLF))(i)?;
-    // FIXME: read trailers if any. we should not expect a CRLF after a chunk of
-    // length zero, but a series of headers.
-    let (i, data) = terminated(take(len), tag(CRLF))(i)?;
-
-    Ok((i, Chunk { len, data }))
-}
-
 /// Parses a chunked transfer coding chunk size (hex text followed by CRLF)
 pub fn chunk_size(i: AggSlice) -> IResult<AggSlice, u64> {
     terminated(u64_text_hex, tag(CRLF))(i)

--- a/src/h1/server.rs
+++ b/src/h1/server.rs
@@ -7,7 +7,7 @@ use crate::{
     bufpool::{AggBuf, IoChunkList},
     io::WriteOwned,
     util::{read_and_parse, write_all_list, SemanticError},
-    Body, Headers, IoChunkable, ReadWriteOwned, Request, Response,
+    Body, Headers, IoChunk, IoChunkable, ReadWriteOwned, Request, Response,
 };
 
 use super::{
@@ -95,19 +95,15 @@ pub async fn serve(
         let connection_close = req.headers.is_connection_close();
         let content_len = req.headers.content_length().unwrap_or_default();
 
-        let mut req_body = H1Body {
-            transport: transport.clone(),
-            buf: Some(client_buf),
-            kind: if chunked {
+        let mut req_body = H1Body::new(
+            transport.clone(),
+            client_buf,
+            if chunked {
                 H1BodyKind::Chunked
-            } else if content_len > 0 {
-                H1BodyKind::ContentLength(content_len)
             } else {
-                H1BodyKind::Empty
+                H1BodyKind::ContentLength(content_len)
             },
-            read: 0,
-            eof: false,
-        };
+        );
 
         let res_handle = Responder::new(transport.clone());
 
@@ -119,13 +115,9 @@ pub async fn serve(
         // TODO: if we sent `connection: close` we should close now
         _ = resp;
 
-        if !req_body.eof() {
-            return Err(eyre::eyre!(
-                "request body not drained, have to close connection"
-            ));
-        }
-
-        client_buf = req_body.buf.take().unwrap();
+        client_buf = req_body
+            .into_buf()
+            .ok_or_else(|| eyre::eyre!("request body not drained, have to close connection"))?;
 
         if connection_close {
             debug!("client requested connection close");
@@ -229,11 +221,25 @@ impl<T> Responder<T, ExpectResponseBody>
 where
     T: WriteOwned,
 {
+    /// Send multiple response body chunks (as many as there are in the chunkable).
+    pub async fn write_chunkable(
+        self,
+        chunkable: impl IoChunkable,
+    ) -> eyre::Result<Responder<T, ExpectResponseBody>> {
+        let mut this = self;
+        let mut offset = 0;
+        while let Some(chunk) = chunkable.next_chunk(offset) {
+            offset += chunk.len() as u32;
+            this = this.write_chunk(chunk).await?;
+        }
+        Ok(this)
+    }
+
     /// Send a response body chunk. Errors out if sending more than the
     /// announced content-length.
-    pub async fn write_body_chunk(
+    pub async fn write_chunk(
         self,
-        chunk: impl IoChunkable,
+        chunk: IoChunk,
     ) -> eyre::Result<Responder<T, ExpectResponseBody>> {
         super::body::write_h1_body_chunk(self.transport.as_ref(), chunk, self.state.mode).await?;
         Ok(self)

--- a/src/h1/server.rs
+++ b/src/h1/server.rs
@@ -4,10 +4,10 @@ use eyre::Context;
 use tracing::debug;
 
 use crate::{
-    bufpool::{AggBuf, Buf, IoChunkList},
+    bufpool::{AggBuf, IoChunkList},
     io::WriteOwned,
     util::{read_and_parse, write_all_list, SemanticError},
-    Body, Headers, ReadWriteOwned, Request, Response,
+    Body, Headers, IoChunkable, ReadWriteOwned, Request, Response,
 };
 
 use super::{
@@ -233,7 +233,7 @@ where
     /// announced content-length.
     pub async fn write_body_chunk(
         self,
-        chunk: Buf,
+        chunk: impl IoChunkable,
     ) -> eyre::Result<Responder<T, ExpectResponseBody>> {
         super::body::write_h1_body_chunk(self.transport.as_ref(), chunk, self.state.mode).await?;
         Ok(self)

--- a/src/h1/server.rs
+++ b/src/h1/server.rs
@@ -252,14 +252,14 @@ where
     /// 205 or 304, or if the body wasn't sent with chunked transfer encoding.
     pub async fn finish_body(
         self,
-        trailers: Option<Headers>,
+        trailers: Option<Box<Headers>>,
     ) -> eyre::Result<Responder<T, ResponseDone>> {
         super::body::write_h1_body_end(self.transport.as_ref(), self.state.mode).await?;
 
         if let Some(trailers) = trailers {
             // TODO: check all preconditions
             let mut list = IoChunkList::default();
-            encode_headers(trailers, &mut list)?;
+            encode_headers(*trailers, &mut list)?;
 
             let list = write_all_list(self.transport.as_ref(), list)
                 .await

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -59,7 +59,9 @@ pub enum BodyChunk {
 
     /// The body finished, and it matched the announced content-length,
     /// or we were using a framed protocol
-    Done,
+    Done {
+        trailers: Option<Box<Headers>>,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,7 +74,7 @@ impl fmt::Display for BodyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "body error: {:?}", self.reason)?;
         if let Some(context) = &self.context {
-            write!(f, " ({:?})", context)
+            write!(f, " ({context:?})")
         } else {
             Ok(())
         }
@@ -148,6 +150,6 @@ impl Body for () {
     }
 
     async fn next_chunk(&mut self) -> eyre::Result<BodyChunk> {
-        Ok(BodyChunk::Done)
+        Ok(BodyChunk::Done { trailers: None })
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,10 +1,10 @@
 mod headers;
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 
 pub use headers::*;
 use tracing::debug;
 
-use crate::bufpool::{AggSlice, Buf};
+use crate::{bufpool::AggSlice, IoChunk};
 
 /// An HTTP request
 pub struct Request {
@@ -55,9 +55,78 @@ impl Response {
 
 /// A body chunk
 pub enum BodyChunk {
-    Buf(Buf),
-    AggSlice(AggSlice),
-    Eof,
+    Chunk(IoChunk),
+
+    /// The body finished, and it matched the announced content-length,
+    /// or we were using a framed protocol
+    Done,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub struct BodyError {
+    reason: BodyErrorReason,
+    context: Option<Box<dyn Debug + Send + Sync>>,
+}
+
+impl fmt::Display for BodyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "body error: {:?}", self.reason)?;
+        if let Some(context) = &self.context {
+            write!(f, " ({:?})", context)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BodyErrorReason {
+    // next_chunk() was called after an error was returned
+    CalledNextChunkAfterError,
+
+    // while doing chunked transfer-encoding, we expected a chunk size
+    // but the connection closed/errored in some way
+    ClosedWhileReadingChunkSize,
+
+    // while doing chunked transfer-encoding, we expected a chunk size,
+    // but what we read wasn't a hex number followed by CRLF
+    InvalidChunkSize,
+
+    // while doing chunked transfer-encoding, the connection was closed
+    // in the middle of reading a chunk's data
+    ClosedWhileReadingChunkData,
+
+    // while reading a content-length body, the connection was closed
+    ClosedWhileReadingContentLength,
+
+    // while doing chunked transfer-encoding, there was a read error
+    // in the middle of reading a chunk's data
+    ErrorWhileReadingChunkData,
+
+    // while doing chunked transfer-encoding, the connection was closed
+    // in the middle of reading the
+    ClosedWhileReadingChunkTerminator,
+
+    // while doing chunked transfer-encoding, we read the chunk size,
+    // then that much data, but then encountered something other than
+    // a CRLF
+    InvalidChunkTerminator,
+}
+
+impl BodyErrorReason {
+    pub fn as_err(self) -> BodyError {
+        BodyError {
+            reason: self,
+            context: None,
+        }
+    }
+
+    pub fn with_cx(self, context: impl Debug + Send + Sync + 'static) -> BodyError {
+        BodyError {
+            reason: self,
+            context: Some(Box::new(context)),
+        }
+    }
 }
 
 pub trait Body: Debug
@@ -79,6 +148,6 @@ impl Body for () {
     }
 
     async fn next_chunk(&mut self) -> eyre::Result<BodyChunk> {
-        Ok(BodyChunk::Eof)
+        Ok(BodyChunk::Done)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,7 @@ where
 {
     loop {
         debug!("reading+parsing ({} bytes so far)", buf.read().len());
-        let slice = buf.read().slice(0..buf.read().len());
+        let slice = buf.read().read_slice();
 
         let (rest, req) = match parser(slice) {
             Ok(t) => t,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -191,7 +191,7 @@ fn request_api() {
                         BodyChunk::AggSlice(s) => {
                             debug!("got a chunk: {:?}", s.to_vec().hex_dump());
                         }
-                        BodyChunk::Eof => {
+                        BodyChunk::Done => {
                             break;
                         }
                     }
@@ -411,7 +411,7 @@ fn proxy_verbose() {
                                     }
                                 }
                             }
-                            BodyChunk::Eof => {
+                            BodyChunk::Done => {
                                 // should we do something here in case of
                                 // content-length mismatches or something?
                                 break;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -395,7 +395,7 @@ fn proxy_verbose() {
                     loop {
                         match body.next_chunk().await? {
                             BodyChunk::Buf(buf) => {
-                                respond = respond.write_body_chunk(buf).await?;
+                                respond = respond.write_chunk(buf).await?;
                             }
                             BodyChunk::AggSlice(slice) => {
                                 let mut list = IoChunkList::default();
@@ -406,7 +406,7 @@ fn proxy_verbose() {
                                         IoChunk::Static(_) => unreachable!(),
                                         IoChunk::Vec(_) => unreachable!(),
                                         IoChunk::Buf(buf) => {
-                                            respond = respond.write_body_chunk(buf).await?;
+                                            respond = respond.write_chunk(buf).await?;
                                         }
                                     }
                                 }

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,0 +1,93 @@
+#![allow(incomplete_features)]
+#![allow(unused_attributes)]
+#![feature(type_alias_impl_trait)]
+#![feature(async_fn_in_trait)]
+
+use hring::{h1, Body, BodyChunk, Response, WriteOwned};
+use std::{cell::RefCell, net::SocketAddr, rc::Rc};
+use tracing::debug;
+
+pub type TransportPool = Rc<RefCell<Vec<Rc<tokio_uring::net::TcpStream>>>>;
+
+pub struct ProxyDriver {
+    pub upstream_addr: SocketAddr,
+    pub pool: TransportPool,
+}
+
+impl h1::ServerDriver for ProxyDriver {
+    async fn handle<T: WriteOwned>(
+        &self,
+        req: hring::Request,
+        req_body: &mut impl Body,
+        respond: h1::Responder<T, h1::ExpectResponseHeaders>,
+    ) -> eyre::Result<h1::Responder<T, h1::ResponseDone>> {
+        let transport = {
+            let mut pool = self.pool.borrow_mut();
+            pool.pop()
+        };
+
+        let transport = if let Some(transport) = transport {
+            debug!("re-using existing transport!");
+            transport
+        } else {
+            debug!("making new connection to upstream!");
+            Rc::new(tokio_uring::net::TcpStream::connect(self.upstream_addr).await?)
+        };
+
+        let driver = ProxyClientDriver { respond };
+
+        let (transport, res) = h1::request(transport, req, req_body, driver).await?;
+
+        if let Some(transport) = transport {
+            let mut pool = self.pool.borrow_mut();
+            pool.push(transport);
+        }
+
+        Ok(res)
+    }
+}
+
+struct ProxyClientDriver<T>
+where
+    T: WriteOwned,
+{
+    respond: h1::Responder<T, h1::ExpectResponseHeaders>,
+}
+
+impl<T> h1::ClientDriver for ProxyClientDriver<T>
+where
+    T: WriteOwned,
+{
+    type Return = h1::Responder<T, h1::ResponseDone>;
+
+    async fn on_informational_response(&self, res: Response) -> eyre::Result<()> {
+        debug!("Got informational response {}", res.code);
+        Ok(())
+    }
+
+    async fn on_final_response(
+        self,
+        res: Response,
+        body: &mut impl Body,
+    ) -> eyre::Result<Self::Return> {
+        let respond = self.respond;
+        let mut respond = respond.write_final_response(res).await?;
+
+        let trailers = loop {
+            match body.next_chunk().await? {
+                BodyChunk::Chunk(chunk) => {
+                    respond = respond.write_chunk(chunk).await?;
+                }
+                BodyChunk::Done { trailers } => {
+                    // should we do something here in case of
+                    // content-length mismatches or something?
+                    break trailers;
+                }
+            }
+        };
+
+        let respond = respond.finish_body(trailers).await?;
+
+        Ok(respond)
+    }
+}

--- a/tests/testbed.rs
+++ b/tests/testbed.rs
@@ -1,0 +1,40 @@
+use std::{any::Any, net::SocketAddr, process::Stdio};
+
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::Command,
+};
+use tracing::debug;
+
+pub async fn start() -> eyre::Result<(SocketAddr, impl Any)> {
+    let (addr_tx, addr_rx) = tokio::sync::oneshot::channel::<SocketAddr>();
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut cmd = Command::new(format!(
+        "{manifest_dir}/hyper-testbed/target/release/hyper-testbed"
+    ));
+    cmd.stdout(Stdio::piped());
+    cmd.kill_on_drop(true);
+
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().unwrap();
+    let mut addr_tx = Some(addr_tx);
+
+    tokio_uring::spawn(async move {
+        let stdout = BufReader::new(stdout);
+        let mut lines = stdout.lines();
+        while let Some(line) = lines.next_line().await.unwrap() {
+            if let Some(rest) = line.strip_prefix("I listen on ") {
+                let addr = rest.parse::<SocketAddr>().unwrap();
+                if let Some(addr_tx) = addr_tx.take() {
+                    addr_tx.send(addr).unwrap();
+                }
+            } else {
+                debug!("[upstream] {}", line);
+            }
+        }
+    });
+
+    let upstream_addr = addr_rx.await?;
+    Ok((upstream_addr, child))
+}


### PR DESCRIPTION
Before this PR, when doing `transfer-encoding: chunked`, chunks were read _entirely_. This could block needlessly.

Now, there's a state machine. Also, the `BodyChunk` enum has been simplified, there's better error handling, `IoChunk` is used instead of having to deal with `AggSlice` separately, there's more utility methods on `AggBuf`, etc.