### PR TITLE
Add more tests: echo body (content-len)

### DIFF
--- a/src/h1/body.rs
+++ b/src/h1/body.rs
@@ -1,6 +1,7 @@
 use std::{fmt, rc::Rc};
 
-use tracing::debug;
+use pretty_hex::PrettyHex;
+use tracing::{debug, trace};
 
 use crate::{
     bufpool::{AggBuf, IoChunkList},
@@ -140,6 +141,7 @@ impl ContentLengthDecoder {
         let chunk = buf.take_contiguous_at_most(remain as u32);
         match chunk {
             Some(chunk) => {
+                trace!("got chunk {}", chunk.hex_dump());
                 self.read += chunk.len() as u64;
                 buf_slot.replace(buf);
                 Ok(BodyChunk::Chunk(chunk.into()))

--- a/tests/helpers/tracing_common.rs
+++ b/tests/helpers/tracing_common.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{filter::Targets, layer::SubscriberExt, util::Subscriber
 /// test, which is a limitation we accept.
 pub(crate) fn setup_tracing() {
     let filter_layer = Targets::new()
-        .with_default(Level::DEBUG)
+        .with_default(Level::TRACE)
         .with_target("hring::io", Level::TRACE)
         .with_target("want", Level::INFO);
 


### PR DESCRIPTION
This tests the `/echo-body` endpoint, with both content-length and chunked transfer encoding bodies.