### PR TITLE
Keep making API more ergonomic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ An HTTP implementation on top of io_uring
 
 [dependencies]
 eyre = { version = "0.6.8", default-features = false }
+http = "0.2.8"
 memchr = "2.5.0"
 memmap2 = { version = "0.5.7", default-features = false }
 nom = { version = "7.1.1", default-features = false }

--- a/src/buffet/piece.rs
+++ b/src/buffet/piece.rs
@@ -1,10 +1,6 @@
 //! Types for performing vectored I/O.
 
-use std::{
-    fmt::{Display, Formatter},
-    ops::Deref,
-    str::Utf8Error,
-};
+use std::{fmt, ops::Deref, str::Utf8Error};
 
 use tokio_uring::buf::IoBuf;
 
@@ -75,6 +71,11 @@ impl Piece {
             Piece::Vec(vec) => vec,
             Piece::Roll(roll) => roll,
         }
+    }
+
+    /// Decode as utf-8 (borrowed)
+    pub fn as_str(&self) -> Result<&str, Utf8Error> {
+        std::str::from_utf8(self.as_ref())
     }
 
     /// Decode as utf-8
@@ -166,8 +167,14 @@ pub struct PieceStr {
     piece: Piece,
 }
 
-impl Display for PieceStr {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for PieceStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Debug::fmt(&self[..], f)
+    }
+}
+
+impl fmt::Display for PieceStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         f.pad(self)
     }
 }

--- a/src/h1/encode.rs
+++ b/src/h1/encode.rs
@@ -1,3 +1,5 @@
+use http::Version;
+
 use crate::{
     buffet::PieceList,
     types::{Headers, Request, Response},
@@ -8,8 +10,9 @@ pub(crate) fn encode_request(req: Request, list: &mut PieceList) -> eyre::Result
     list.push(" ");
     list.push(req.path);
     match req.version {
-        1 => list.push(" HTTP/1.1\r\n"),
-        _ => return Err(eyre::eyre!("unsupported HTTP version 1.{}", req.version)),
+        Version::HTTP_10 => list.push(" HTTP/1.0\r\n"),
+        Version::HTTP_11 => list.push(" HTTP/1.1\r\n"),
+        _ => return Err(eyre::eyre!("unsupported HTTP version {:?}", req.version)),
     }
     for header in req.headers {
         list.push(header.name);
@@ -23,8 +26,9 @@ pub(crate) fn encode_request(req: Request, list: &mut PieceList) -> eyre::Result
 
 pub(crate) fn encode_response(res: Response, list: &mut PieceList) -> eyre::Result<()> {
     match res.version {
-        1 => list.push(&b"HTTP/1.1 "[..]),
-        _ => return Err(eyre::eyre!("unsupported HTTP version 1.{}", res.version)),
+        Version::HTTP_10 => list.push(&b"HTTP/1.0 "[..]),
+        Version::HTTP_11 => list.push(&b"HTTP/1.1 "[..]),
+        _ => return Err(eyre::eyre!("unsupported HTTP version {:?}", res.version)),
     }
 
     // cf. https://github.com/hyperium/http/pull/569 - it's already 'static,

--- a/src/h1/parse.rs
+++ b/src/h1/parse.rs
@@ -3,7 +3,7 @@
 //! As of June 2022, the authoritative document for HTTP/1.1
 //! is https://www.rfc-editor.org/rfc/rfc9110
 
-use http::StatusCode;
+use http::{StatusCode, Version};
 use nom::{
     bytes::streaming::{tag, take, take_until, take_while1},
     combinator::{map_res, opt},
@@ -115,12 +115,12 @@ fn u64_text_hex(i: Roll) -> IResult<Roll, u64> {
     f(i)
 }
 
-pub fn http_version(i: Roll) -> IResult<Roll, u8> {
+pub fn http_version(i: Roll) -> IResult<Roll, Version> {
     let (i, _) = tag(&b"HTTP/1."[..])(i)?;
     let (i, version) = take(1usize)(i)?;
     let version = match version.iter().next().unwrap() {
-        b'0' => 0,
-        b'1' => 1,
+        b'0' => Version::HTTP_10,
+        b'1' => Version::HTTP_11,
         _ => {
             return Err(nom::Err::Error(nom::error::Error::new(
                 i,

--- a/src/h1/server.rs
+++ b/src/h1/server.rs
@@ -166,7 +166,7 @@ where
         self,
         res: Response,
     ) -> eyre::Result<Responder<T, ExpectResponseHeaders>> {
-        if res.code >= 200 {
+        if !res.status.is_informational() {
             return Err(eyre::eyre!("interim response must have status code 1xx"));
         }
 
@@ -191,7 +191,7 @@ where
             BodyWriteMode::Chunked
         };
 
-        if res.code < 200 {
+        if res.status.is_informational() {
             return Err(eyre::eyre!("final response must have status code >= 200"));
         }
 

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -9,7 +9,7 @@ const HEADERS_SMALLVEC_CAPACITY: usize = 32;
 #[derive(Default)]
 pub struct Headers {
     // TODO: this could/should be a multimap. http's multimap is neat but doesn't
-    // support `AggSlice`. The `HeaderName` type should probably have three
+    // support `Piece`/`PieceStr`. The `HeaderName` type should probably have three
     // variants:
     //   WellKnown (TransferEncoding, Connection, etc.)
     //   &'static [u8] (custom)

--- a/src/types/headers.rs
+++ b/src/types/headers.rs
@@ -2,7 +2,7 @@
 
 use smallvec::SmallVec;
 
-use crate::Roll;
+use crate::{Piece, PieceStr};
 
 const HEADERS_SMALLVEC_CAPACITY: usize = 32;
 
@@ -23,8 +23,8 @@ impl Headers {
         self.headers.push(header);
     }
 
-    /// Returns true if we have this key/value combinatoin
-    pub fn has_kv(&self, k: impl AsRef<[u8]>, v: impl AsRef<[u8]>) -> bool {
+    /// Returns true if we have this key/value combination
+    pub fn has_kv(&self, k: impl AsRef<str>, v: impl AsRef<[u8]>) -> bool {
         let k = k.as_ref();
         let v = v.as_ref();
 
@@ -49,8 +49,7 @@ impl Headers {
     /// Returns the content-length header
     pub fn content_length(&self) -> Option<u64> {
         for h in self {
-            if h.name.eq_ignore_ascii_case(b"content-length") {
-                // TODO: introduce RollStr
+            if h.name.eq_ignore_ascii_case("content-length") {
                 if let Ok(s) = std::str::from_utf8(&h.value[..]) {
                     if let Ok(l) = s.parse() {
                         return Some(l);
@@ -81,6 +80,6 @@ impl IntoIterator for Headers {
 }
 
 pub struct Header {
-    pub name: Roll,
-    pub value: Roll,
+    pub name: PieceStr,
+    pub value: Piece,
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Debug};
 
 use tracing::debug;
 
-use crate::{Piece, PieceStr, Roll};
+use crate::{Piece, PieceStr};
 
 mod headers;
 pub use headers::*;
@@ -28,7 +28,7 @@ impl Request {
     pub(crate) fn debug_print(&self) {
         debug!(method = %self.method, path = %self.path, version = %self.version, "got request");
         for h in &self.headers {
-            debug!(name = %h.name.to_string_lossy(), value = %h.value.to_string_lossy(), "got header");
+            debug!(name = %h.name, value = ?h.value.as_str(), "got header");
         }
     }
 }
@@ -42,7 +42,7 @@ pub struct Response {
     pub code: u16,
 
     /// Human-readable string following the status code
-    pub reason: Roll,
+    pub reason: PieceStr,
 
     /// Response headers
     pub headers: Headers,
@@ -50,9 +50,9 @@ pub struct Response {
 
 impl Response {
     pub(crate) fn debug_print(&self) {
-        debug!(code = %self.code, reason = %self.reason.to_string_lossy(), version = %self.version, "got response");
+        debug!(code = %self.code, reason = %self.reason, version = %self.version, "got response");
         for h in &self.headers {
-            debug!(name = %h.name.to_string_lossy(), value = %h.value.to_string_lossy(), "got header");
+            debug!(name = %h.name, value = ?h.value.as_str(), "got header");
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Debug};
 
-use http::StatusCode;
+use http::{StatusCode, Version};
 use tracing::debug;
 
 use crate::{Piece, PieceStr};
@@ -18,16 +18,27 @@ pub struct Request {
     /// Requested entity
     pub path: PieceStr,
 
-    /// The 'b' in 'HTTP/1.b'
-    pub version: u8,
+    /// The HTTP version used
+    pub version: Version,
 
     /// Request headers
     pub headers: Headers,
 }
 
+impl Default for Request {
+    fn default() -> Self {
+        Self {
+            method: Method::Get,
+            path: "/".into(),
+            version: Version::HTTP_11,
+            headers: Default::default(),
+        }
+    }
+}
+
 impl Request {
     pub(crate) fn debug_print(&self) {
-        debug!(method = %self.method, path = %self.path, version = %self.version, "got request");
+        debug!(method = %self.method, path = %self.path, version = ?self.version, "got request");
         for h in &self.headers {
             debug!(name = %h.name, value = ?h.value.as_str(), "got header");
         }
@@ -37,7 +48,7 @@ impl Request {
 /// An HTTP response
 pub struct Response {
     /// The 'b' in 'HTTP/1.b'
-    pub version: u8,
+    pub version: Version,
 
     /// Status code (1xx-5xx)
     pub status: StatusCode,
@@ -46,9 +57,19 @@ pub struct Response {
     pub headers: Headers,
 }
 
+impl Default for Response {
+    fn default() -> Self {
+        Self {
+            version: Version::HTTP_11,
+            status: StatusCode::OK,
+            headers: Default::default(),
+        }
+    }
+}
+
 impl Response {
     pub(crate) fn debug_print(&self) {
-        debug!(code = %self.status, version = %self.version, "got response");
+        debug!(code = %self.status, version = ?self.version, "got response");
         for h in &self.headers {
             debug!(name = %h.name, value = ?h.value.as_str(), "got header");
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Debug};
 
+use http::StatusCode;
 use tracing::debug;
 
 use crate::{Piece, PieceStr};
@@ -39,10 +40,7 @@ pub struct Response {
     pub version: u8,
 
     /// Status code (1xx-5xx)
-    pub code: u16,
-
-    /// Human-readable string following the status code
-    pub reason: PieceStr,
+    pub status: StatusCode,
 
     /// Response headers
     pub headers: Headers,
@@ -50,7 +48,7 @@ pub struct Response {
 
 impl Response {
     pub(crate) fn debug_print(&self) {
-        debug!(code = %self.code, reason = %self.reason, version = %self.version, "got response");
+        debug!(code = %self.status, version = %self.version, "got response");
         for h in &self.headers {
             debug!(name = %h.name, value = ?h.value.as_str(), "got header");
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,6 +9,7 @@ use hring::{
     h1, Body, BodyChunk, ChanRead, ChanWrite, Headers, Method, ReadWritePair, Request, Response,
     RollMut, WriteOwned,
 };
+use http::StatusCode;
 use httparse::{Status, EMPTY_HEADER};
 use pretty_assertions::assert_eq;
 use pretty_hex::PrettyHex;
@@ -62,9 +63,8 @@ fn serve_api() {
 
                 let res = res
                     .write_interim_response(Response {
-                        code: 101,
+                        status: StatusCode::CONTINUE,
                         headers: Headers::default(),
-                        reason: "Continue".into(),
                         version: 1,
                     })
                     .await?;
@@ -75,9 +75,8 @@ fn serve_api() {
 
                 let res = res
                     .write_final_response(Response {
-                        code: 200,
+                        status: StatusCode::OK,
                         headers: Headers::default(),
-                        reason: "OK".into(),
                         version: 1,
                     })
                     .await?;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,8 +6,8 @@ mod helpers;
 
 use bytes::BytesMut;
 use hring::{
-    h1, Body, BodyChunk, ChanRead, ChanWrite, Headers, Method, ReadWritePair, Request, Response,
-    RollMut, WriteOwned,
+    h1, Body, BodyChunk, ChanRead, ChanWrite, Method, ReadWritePair, Request, Response, RollMut,
+    WriteOwned,
 };
 use http::StatusCode;
 use httparse::{Status, EMPTY_HEADER};
@@ -64,8 +64,7 @@ fn serve_api() {
                 let res = res
                     .write_interim_response(Response {
                         status: StatusCode::CONTINUE,
-                        headers: Headers::default(),
-                        version: 1,
+                        ..Default::default()
                     })
                     .await?;
 
@@ -76,8 +75,7 @@ fn serve_api() {
                 let res = res
                     .write_final_response(Response {
                         status: StatusCode::OK,
-                        headers: Headers::default(),
-                        version: 1,
+                        ..Default::default()
                     })
                     .await?;
 
@@ -143,8 +141,7 @@ fn request_api() {
         let req = Request {
             method: Method::Get,
             path: "/".into(),
-            version: 1,
-            headers: Headers::default(),
+            ..Default::default()
         };
 
         struct TestDriver {}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -111,7 +111,7 @@ fn serve_api() {
             debug!("Got a complete response: {res:?}");
 
             match res.code {
-                Some(101) => {
+                Some(100) => {
                     assert_eq!(res.reason, Some("Continue"));
                     res_buf = res_buf.split_off(body_offset);
                 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -59,19 +59,17 @@ fn serve_api() {
                 let mut buf = RollMut::alloc()?;
 
                 buf.put(b"Continue")?;
-                let reason = buf.take_all();
 
                 let res = res
                     .write_interim_response(Response {
                         code: 101,
                         headers: Headers::default(),
-                        reason,
+                        reason: "Continue".into(),
                         version: 1,
                     })
                     .await?;
 
                 buf.put(b"OK")?;
-                let reason = buf.take_all();
 
                 _ = buf;
 
@@ -79,7 +77,7 @@ fn serve_api() {
                     .write_final_response(Response {
                         code: 200,
                         headers: Headers::default(),
-                        reason,
+                        reason: "OK".into(),
                         version: 1,
                     })
                     .await?;

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -61,7 +61,7 @@ where
     type Return = h1::Responder<T, h1::ResponseDone>;
 
     async fn on_informational_response(&self, res: Response) -> eyre::Result<()> {
-        debug!("Got informational response {}", res.code);
+        debug!("Got informational response {}", res.status);
         Ok(())
     }
 


### PR DESCRIPTION
This pulls in the `http` crate, which is larged than I'd like, but it gives us solid types for `StatusCode` and `Version`, which I don't care to duplicate right now.