### PR TITLE
Use http::HeaderMap

### DIFF
--- a/src/h1/client.rs
+++ b/src/h1/client.rs
@@ -8,7 +8,7 @@ use crate::{
     io::ReadWriteOwned,
     types::Request,
     util::{read_and_parse, write_all_list},
-    Body, Response, RollMut,
+    Body, HeadersExt, Response, RollMut,
 };
 
 use super::{

--- a/src/h1/server.rs
+++ b/src/h1/server.rs
@@ -7,7 +7,7 @@ use crate::{
     buffet::PieceList,
     io::WriteOwned,
     util::{read_and_parse, write_all_list, SemanticError},
-    Body, Headers, Piece, ReadWriteOwned, Request, Response, RollMut,
+    Body, Headers, HeadersExt, Piece, ReadWriteOwned, Request, Response, RollMut,
 };
 
 use super::{

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -39,8 +39,8 @@ impl Default for Request {
 impl Request {
     pub(crate) fn debug_print(&self) {
         debug!(method = %self.method, path = %self.path, version = ?self.version, "got request");
-        for h in &self.headers {
-            debug!(name = %h.name, value = ?h.value.as_str(), "got header");
+        for (name, value) in &self.headers {
+            debug!(%name, value = ?value.as_str(), "got header");
         }
     }
 }
@@ -70,8 +70,8 @@ impl Default for Response {
 impl Response {
     pub(crate) fn debug_print(&self) {
         debug!(code = %self.status, version = ?self.version, "got response");
-        for h in &self.headers {
-            debug!(name = %h.name, value = ?h.value.as_str(), "got header");
+        for (name, value) in &self.headers {
+            debug!(%name, value = ?value.as_str(), "got header");
         }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -6,8 +6,8 @@ mod helpers;
 
 use bytes::BytesMut;
 use hring::{
-    h1, Body, BodyChunk, ChanRead, ChanWrite, Method, ReadWritePair, Request, Response, RollMut,
-    WriteOwned,
+    h1, Body, BodyChunk, ChanRead, ChanWrite, HeadersExt, Method, ReadWritePair, Request, Response,
+    RollMut, WriteOwned,
 };
 use http::StatusCode;
 use httparse::{Status, EMPTY_HEADER};


### PR DESCRIPTION
Closes #33.

This makes the hring API more familiar compared to other Rust HTTP implementations. It also gives us low-cost "known header name" storage, deals with `insert` / `append` subtleties, etc.