### PR TITLE
Do minimal error handling when driver returns an error on h2

### DIFF
--- a/src/h2/encode.rs
+++ b/src/h2/encode.rs
@@ -1,8 +1,10 @@
 use std::fmt;
 
+use http::{StatusCode, Version};
 use tokio::sync::mpsc;
+use tracing::warn;
 
-use crate::{h1, Encoder, Piece, Response};
+use crate::{h1::body::BodyWriteMode, Encoder, Piece, Response};
 
 use super::parse::{Frame, StreamId};
 
@@ -34,9 +36,16 @@ impl fmt::Debug for H2EventPayload {
     }
 }
 
+pub(crate) enum EncoderState {
+    ExpectResponseHeaders,
+    ExpectResponseBody,
+    ResponseDone,
+}
+
 pub struct H2Encoder {
     pub(crate) stream_id: StreamId,
     pub(crate) tx: mpsc::Sender<H2ConnEvent>,
+    pub(crate) state: EncoderState,
 }
 
 impl H2Encoder {
@@ -58,7 +67,12 @@ impl H2Encoder {
 
 impl Encoder for H2Encoder {
     async fn write_response(&mut self, res: Response) -> eyre::Result<()> {
+        // TODO: don't panic here
+        assert!(matches!(self.state, EncoderState::ExpectResponseHeaders));
+
         self.send(H2EventPayload::Headers(res)).await?;
+        self.state = EncoderState::ExpectResponseBody;
+
         Ok(())
     }
 
@@ -66,20 +80,64 @@ impl Encoder for H2Encoder {
     async fn write_body_chunk(
         &mut self,
         chunk: crate::Piece,
-        _mode: h1::body::BodyWriteMode,
+        _mode: BodyWriteMode,
     ) -> eyre::Result<()> {
+        assert!(matches!(self.state, EncoderState::ExpectResponseBody));
+
         self.send(H2EventPayload::BodyChunk(chunk)).await?;
         Ok(())
     }
 
     // TODO: BodyWriteMode is not relevant for h2
-    async fn write_body_end(&mut self, _mode: h1::body::BodyWriteMode) -> eyre::Result<()> {
+    async fn write_body_end(&mut self, _mode: BodyWriteMode) -> eyre::Result<()> {
+        assert!(matches!(self.state, EncoderState::ExpectResponseBody));
+
         self.send(H2EventPayload::BodyEnd).await?;
+        self.state = EncoderState::ResponseDone;
+
         Ok(())
     }
 
     // TODO: handle trailers
     async fn write_trailers(&mut self, _trailers: Box<crate::Headers>) -> eyre::Result<()> {
+        assert!(matches!(self.state, EncoderState::ResponseDone));
+
         todo!("write trailers")
+    }
+}
+
+impl Drop for H2Encoder {
+    fn drop(&mut self) {
+        let mut evs = vec![];
+
+        match self.state {
+            EncoderState::ExpectResponseHeaders => {
+                evs.push(self.event(H2EventPayload::Headers(Response {
+                    version: Version::HTTP_11,
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    headers: Default::default(),
+                })));
+                evs.push(self.event(H2EventPayload::BodyEnd));
+            }
+            EncoderState::ExpectResponseBody => {
+                // TODO: this should probably be RST_STREAM instead
+                evs.push(self.event(H2EventPayload::BodyEnd));
+            }
+            EncoderState::ResponseDone => {
+                // ah, good.
+            }
+        }
+
+        if !evs.is_empty() {
+            let tx = self.tx.clone();
+            tokio_uring::spawn(async move {
+                for ev in evs {
+                    if tx.send(ev).await.is_err() {
+                        warn!("could not send event to h2 connection handler");
+                        break;
+                    }
+                }
+            });
+        }
     }
 }

--- a/src/h2/server.rs
+++ b/src/h2/server.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 use crate::{
     h2::{
         body::H2Body,
-        encode::{H2ConnEvent, H2Encoder, H2EventPayload},
+        encode::{EncoderState, H2ConnEvent, H2Encoder, H2EventPayload},
         parse::{
             parse_headers_priority, DataFlags, Frame, FrameType, HeadersFlags, SettingsFlags,
             StreamId,
@@ -214,7 +214,7 @@ async fn h2_read_loop(
                 };
 
                 if s.contains(SettingsFlags::Ack) {
-                    debug!("Peer has acknowledge our settings, cool");
+                    debug!("Peer has acknowledged our settings, cool");
                 } else {
                     // TODO: actually apply settings
 
@@ -356,6 +356,7 @@ async fn h2_write_loop(
                         encoder: H2Encoder {
                             stream_id: frame.stream_id,
                             tx: ev_tx.clone(),
+                            state: EncoderState::ExpectResponseHeaders,
                         },
                         state: ExpectResponseHeaders,
                     };
@@ -398,7 +399,7 @@ async fn h2_write_loop(
                                     debug!("Handler completed successfully, gave us a responder");
                                 }
                                 Err(e) => {
-                                    // TODO: actually handle that error
+                                    // TODO: actually handle that error.
                                     debug!("Handler returned an error: {e}")
                                 }
                             }


### PR DESCRIPTION
This at least generates a 500 instead of leaving h2 events hanging