### PR TITLE
Don't read payload if empty, grow buffer as needed

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -2,7 +2,7 @@ name: report
 
 on:
   workflow_run:
-    workflows: [build]
+    workflows: [test]
     types: [completed]
     
 permissions:

--- a/Justfile
+++ b/Justfile
@@ -33,7 +33,7 @@ bench *args:
 h2spec *args:
 	#!/bin/bash -eux
 	echo "This requires h2spec to be installed: https://github.com/summerwind/h2spec"
-	export RUST_LOG=debug
+	export RUST_LOG="${RUST_LOG:-debug}"
 	export RUST_BACKTRACE=1
 	cargo run --manifest-path h2spec-server/Cargo.toml -- {{args}}
 

--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,10 @@ bench *args:
 	RUST_BACKTRACE=1 cargo bench {{args}} -- --plotting-backend plotters
 
 h2spec *args:
+	#!/bin/bash -eux
 	echo "This requires h2spec to be installed: https://github.com/summerwind/h2spec"
+	export RUST_LOG=debug
+	export RUST_BACKTRACE=1
 	cargo run --manifest-path h2spec-server/Cargo.toml -- {{args}}
 
 check:

--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@ ci-test:
 	#!/bin/bash -eux
 	just build-testbed
 	cargo llvm-cov --no-report nextest
-	cargo llvm-cov --no-report run --manifest-path h2spec-server/Cargo.toml -- -j 'target/junit.xml'
+	cargo llvm-cov --no-report run --manifest-path h2spec-server/Cargo.toml -- -j 'target/h2spec-junit.xml'
 	cargo llvm-cov report --lcov --output-path coverage.lcov
 	codecov
 


### PR DESCRIPTION
Closes #50, and also, allows reading frames > 4K via `read_and_parse`. Unsure whether that's wise for `Data` frames, we might need special handling there.