### PR TITLE
h2: Move parsing logic from write loop to read loop

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Publish h2spec Report
         uses: dorny/test-reporter@v1
         with:
-          name: H2Spec Results
+          name: h2spec results
           path: h2spec-junit.xml
           reporter: java-junit

--- a/src/h2/encode.rs
+++ b/src/h2/encode.rs
@@ -10,7 +10,7 @@ use super::parse::{Frame, KnownErrorCode, StreamId};
 
 pub(crate) enum H2ConnEvent {
     Ping(Roll),
-    ClientFrame(Frame, Option<Roll>),
+    ClientFrame(Frame, Roll),
     ServerEvent(H2Event),
     AcknowledgeSettings,
     GoAway {


### PR DESCRIPTION
There was a TODO and it makes sense to do it that way. `h2_write_loop` is only there so we send messages in-order.

This also sneaks in support for padded header frames, so more h2 tests are actually passing.