### PR TITLE
h2: Support padded data frames (h2spec generic/3.1)

### DIFF
--- a/src/h2/encode.rs
+++ b/src/h2/encode.rs
@@ -6,11 +6,10 @@ use tracing::{debug, warn};
 
 use crate::{h1::body::BodyWriteMode, Encoder, Piece, Response, Roll};
 
-use super::parse::{Frame, KnownErrorCode, StreamId};
+use super::parse::{KnownErrorCode, StreamId};
 
 pub(crate) enum H2ConnEvent {
     Ping(Roll),
-    ClientFrame(Frame, Roll),
     ServerEvent(H2Event),
     AcknowledgeSettings,
     GoAway {


### PR DESCRIPTION
This also gets rid of the `ClientFrame` message.