### PR TITLE
h2: Support CONTINUATION frames (wip)

### DIFF
--- a/src/h2/server.rs
+++ b/src/h2/server.rs
@@ -301,6 +301,9 @@ async fn h2_read_loop(
                             }
                         } else {
                             debug!("expecting more headers for stream {}", frame.stream_id);
+                            continuation_state =
+                                ContinuationState::ContinuingHeaders(frame.stream_id);
+
                             {
                                 let mut state = state.borrow_mut();
                                 state.streams.insert(
@@ -414,8 +417,6 @@ async fn h2_read_loop(
                                         )
                                         .map(Some)
                                     } else {
-                                        continuation_state =
-                                            ContinuationState::ContinuingHeaders(frame.stream_id);
                                         debug!(
                                             "have {} field block fragments so far, will read CONTINUATION frames",
                                             headers_data.fragments.len()


### PR DESCRIPTION
Not working yet, apparently the multiple frames cannot be decoded separately:

```
connection error: 
   0: hpack error: StringDecodingError(NotEnoughOctets)

Location:
   /home/amos/bearcove/hring/src/h2/server.rs:519
```

This is annoying since the `hpack` crate requires a single contiguous byte slice, but we can do a bit of copying for what should be an edge case (large headers + small frame size).