### PR TITLE
fix hpack static entries and the README

### DIFF
--- a/crates/hring-hpack/README.md
+++ b/crates/hring-hpack/README.md
@@ -41,7 +41,10 @@ let headers = vec![
 ];
 // The headers are encoded by providing their index (with a bit flag
 // indicating that the indexed representation is used).
-assert_eq!(encoder.encode(&headers), vec![2 | 0x80, 4 | 0x80]);
+assert_eq!(
+   encoder.encode(headers.iter().map(|h| (&h.0[..], &h.1[..]))),
+   vec![2 | 0x80, 4 | 0x80]
+ );
 ```
 
 ## Decoding

--- a/crates/hring-hpack/src/lib.rs
+++ b/crates/hring-hpack/src/lib.rs
@@ -305,7 +305,7 @@ static STATIC_TABLE: &[(&[u8], &[u8])] = &[
     (b":status", b"400"),
     (b":status", b"404"),
     (b":status", b"500"),
-    (b"accept-", b""),
+    (b"accept-charset", b""),
     (b"accept-encoding", b"gzip, deflate"),
     (b"accept-language", b""),
     (b"accept-ranges", b""),


### PR DESCRIPTION
While looking at the upstream hpack repo, saw a PR,
    https://github.com/mlalic/hpack-rs/pull/7
that seems correct to me.

I think the PR would have been merged but the repo seems to no longer be supported.
Quoting from xpepermint:

    I found a serious bug in the static table - an invalid entry.
    Ref: https://tools.ietf.org/html/rfc7541#appendix-A

While at it, might as well pull in the only other PR at this time from the upstream hpack repo.
    https://github.com/mlalic/hpack-rs/pull/4
It doesn't affect the build as it is just a change to the README.md but some people found and filed the issue, and one went so far as to propose this fix. (I haven't tried the fix.)