### PR TITLE
Fix h2spec Request Pseudo-Hader Fields

### DIFF
--- a/crates/hring/src/h2/server.rs
+++ b/crates/hring/src/h2/server.rs
@@ -628,27 +628,37 @@ fn end_headers(
         if &key[..1] == b":" {
             // it's a pseudo-header!
             // TODO: reject headers that occur after pseudo-headers
-            // TODO: reject duplicate pseudo-headers
             match &key[1..] {
                 b"method" => {
                     // TODO: error handling
                     let value: PieceStr = Piece::from(value.to_vec()).to_str().unwrap();
-                    method = Some(Method::try_from(value).unwrap());
+                    if method.replace(Method::try_from(value).unwrap()).is_some() {
+                        unreachable!(); // No duplicate allowed.
+                    }
                 }
                 b"scheme" => {
                     // TODO: error handling
                     let value: PieceStr = Piece::from(value.to_vec()).to_str().unwrap();
-                    scheme = Some(value.parse().unwrap());
+                    if scheme.replace(value.parse().unwrap()).is_some() {
+                        unreachable!(); // No duplicate allowed.
+                    }
                 }
                 b"path" => {
                     // TODO: error handling
                     let value: PieceStr = Piece::from(value.to_vec()).to_str().unwrap();
-                    path = Some(value);
+                    if value.len() == 0 || path.replace(value).is_some() {
+                        unreachable!(); // No empty path nor duplicate allowed.
+
+                    }
                 }
                 b"authority" => {
                     // TODO: error handling
                     let value: PieceStr = Piece::from(value.to_vec()).to_str().unwrap();
-                    authority = Some(value.parse().unwrap());
+                    if authority.replace(value.parse().unwrap()).is_some() {
+                        unreachable!(); // No duplicate allowed. (h2spec doesn't seem to test for
+                                        // this case but rejecting for duplicates seems
+                                        // reasonable.)
+                    }
                 }
                 _ => {
                     debug!("ignoring pseudo-header");


### PR DESCRIPTION
Should fix four failing test cases from h2spec

    8.1.2.3. Request Pseudo-Header Fields

        ❌ Sends a HEADERS frame with empty ":path" pseudo-header field
                GOAWAY Frame (Error Code: PROTOCOL_ERROR)
        ✅ Sends a HEADERS frame that omits ":method" pseudo-header field
        ✅ Sends a HEADERS frame that omits ":scheme" pseudo-header field
        ✅ Sends a HEADERS frame that omits ":path" pseudo-header field
        ❌ Sends a HEADERS frame with duplicated ":method" pseudo-header field
                GOAWAY Frame (Error Code: PROTOCOL_ERROR)
        ❌ Sends a HEADERS frame with duplicated ":scheme" pseudo-header field
                GOAWAY Frame (Error Code: PROTOCOL_ERROR)
        ❌ Sends a HEADERS frame with duplicated ":path" pseudo-header field
                GOAWAY Frame (Error Code: PROTOCOL_ERROR)

Also rejects when duplicate `authority` pseudo-headers are encountered although the h2spec doesn't seem to test for that.