### PR TITLE
Revert workaround for default async methods, closes #85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-01-21"
+channel = "nightly-2023-02-20"
 components = ["llvm-tools-preview"]


### PR DESCRIPTION
No need to go through a freestanding `writev_all` function anymore!