### PR TITLE
Take `&mut self` for ReadOwned and WriteOwned

### DIFF
--- a/crates/hring-buffet/src/io/buf_or_slice.rs
+++ b/crates/hring-buffet/src/io/buf_or_slice.rs
@@ -1,0 +1,52 @@
+use tokio_uring::buf::IoBuf;
+
+pub(crate) enum BufOrSlice<B: IoBuf> {
+    Buf(B),
+    Slice(tokio_uring::buf::Slice<B>),
+}
+
+unsafe impl<B: IoBuf> IoBuf for BufOrSlice<B> {
+    fn stable_ptr(&self) -> *const u8 {
+        match self {
+            BufOrSlice::Buf(b) => b.stable_ptr(),
+            BufOrSlice::Slice(s) => s.stable_ptr(),
+        }
+    }
+
+    fn bytes_init(&self) -> usize {
+        match self {
+            BufOrSlice::Buf(b) => b.bytes_init(),
+            BufOrSlice::Slice(s) => s.bytes_init(),
+        }
+    }
+
+    fn bytes_total(&self) -> usize {
+        match self {
+            BufOrSlice::Buf(b) => b.bytes_total(),
+            BufOrSlice::Slice(s) => s.bytes_total(),
+        }
+    }
+}
+
+impl<B: IoBuf> BufOrSlice<B> {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            BufOrSlice::Buf(b) => b.bytes_init(),
+            BufOrSlice::Slice(s) => s.len(),
+        }
+    }
+
+    /// Consume the first `n` bytes of the buffer (assuming they've been written).
+    /// This turns a `BufOrSlice::Buf` into a `BufOrSlice::Slice`
+    pub(crate) fn consume(self, n: usize) -> Self {
+        assert!(n <= self.len());
+
+        match self {
+            BufOrSlice::Buf(b) => BufOrSlice::Slice(b.slice(n..)),
+            BufOrSlice::Slice(s) => {
+                let n = s.begin() + n;
+                BufOrSlice::Slice(s.into_inner().slice(n..))
+            }
+        }
+    }
+}

--- a/crates/hring-buffet/src/io/chan.rs
+++ b/crates/hring-buffet/src/io/chan.rs
@@ -117,7 +117,7 @@ impl Drop for ChanReadSend {
 }
 
 impl ReadOwned for ChanRead {
-    async fn read<B: IoBufMut>(&self, mut buf: B) -> BufResult<usize, B> {
+    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
         trace!("Reading {} bytes", buf.bytes_total());
         let out =
             unsafe { std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total()) };
@@ -194,7 +194,7 @@ mod tests {
     #[test]
     fn test_chan_reader() {
         tokio_uring::start(async move {
-            let (send, cr) = ChanRead::new();
+            let (send, mut cr) = ChanRead::new();
             let wrote_three = Rc::new(RefCell::new(false));
 
             tokio_uring::spawn({
@@ -253,7 +253,7 @@ mod tests {
                 assert_eq!(n, 0, "reached EOF");
             }
 
-            let (send, cr) = ChanRead::new();
+            let (send, mut cr) = ChanRead::new();
 
             tokio_uring::spawn({
                 async move {

--- a/crates/hring-buffet/src/io/chan.rs
+++ b/crates/hring-buffet/src/io/chan.rs
@@ -175,7 +175,7 @@ impl ChanWrite {
 }
 
 impl WriteOwned for ChanWrite {
-    async fn write<B: IoBuf>(&self, buf: B) -> BufResult<usize, B> {
+    async fn write<B: IoBuf>(&mut self, buf: B) -> BufResult<usize, B> {
         let slice = unsafe { std::slice::from_raw_parts(buf.stable_ptr(), buf.bytes_init()) };
         match self.tx.send(slice.to_vec()).await {
             Ok(()) => (Ok(buf.bytes_init()), buf),

--- a/crates/hring-buffet/src/io/non_uring.rs
+++ b/crates/hring-buffet/src/io/non_uring.rs
@@ -1,0 +1,39 @@
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_uring::{
+    buf::{IoBuf, IoBufMut},
+    BufResult,
+};
+
+use crate::{ReadOwned, WriteOwned};
+
+impl<T> ReadOwned for T
+where
+    T: AsyncRead + Unpin,
+{
+    async fn read<B: IoBufMut>(&mut self, mut buf: B) -> BufResult<usize, B> {
+        let buf_slice =
+            unsafe { std::slice::from_raw_parts_mut(buf.stable_mut_ptr(), buf.bytes_total()) };
+        let res = tokio::io::AsyncReadExt::read(self, buf_slice).await;
+        if let Ok(n) = &res {
+            unsafe {
+                buf.set_init(*n);
+            }
+        }
+        (res, buf)
+    }
+}
+
+impl<T> WriteOwned for T
+where
+    T: AsyncWrite + Unpin,
+{
+    async fn write<B: IoBuf>(&mut self, buf: B) -> BufResult<usize, B> {
+        let buf_slice = unsafe { std::slice::from_raw_parts(buf.stable_ptr(), buf.bytes_init()) };
+        let res = tokio::io::AsyncWriteExt::write(self, buf_slice).await;
+        (res, buf)
+    }
+
+    // TODO: implement writev, for performance. this involves wrapping
+    // everything in `IoSlice`, advancing correctly, etc. It's not fun, but it
+    // should yield a boost for non-uring codepaths.
+}

--- a/crates/hring-buffet/src/io/uring_tcp.rs
+++ b/crates/hring-buffet/src/io/uring_tcp.rs
@@ -1,0 +1,46 @@
+use std::rc::Rc;
+
+use tokio_uring::{
+    buf::{IoBuf, IoBufMut},
+    net::TcpStream,
+    BufResult,
+};
+
+use crate::{ReadOwned, WriteOwned};
+
+pub struct TcpReadHalf(Rc<TcpStream>);
+
+impl ReadOwned for TcpReadHalf {
+    async fn read<B: IoBufMut>(&mut self, buf: B) -> BufResult<usize, B> {
+        self.0.read(buf).await
+    }
+}
+
+pub struct TcpWriteHalf(Rc<TcpStream>);
+
+impl WriteOwned for TcpWriteHalf {
+    async fn write<B: IoBuf>(&mut self, buf: B) -> BufResult<usize, B> {
+        self.0.write(buf).await
+    }
+
+    async fn writev<B: IoBuf>(&mut self, list: Vec<B>) -> BufResult<usize, Vec<B>> {
+        self.0.writev(list).await
+    }
+}
+
+pub trait IntoSplit {
+    type Read: ReadOwned;
+    type Write: WriteOwned;
+
+    fn into_split(self) -> (Self::Read, Self::Write);
+}
+
+impl IntoSplit for TcpStream {
+    type Read = TcpReadHalf;
+    type Write = TcpWriteHalf;
+
+    fn into_split(self) -> (Self::Read, Self::Write) {
+        let self_rc = Rc::new(self);
+        (TcpReadHalf(self_rc.clone()), TcpWriteHalf(self_rc))
+    }
+}

--- a/crates/hring/src/h1/body.rs
+++ b/crates/hring/src/h1/body.rs
@@ -244,7 +244,7 @@ pub enum BodyWriteMode {
 }
 
 pub(crate) async fn write_h1_body(
-    transport: &impl WriteOwned,
+    transport: &mut impl WriteOwned,
     body: &mut impl Body,
     mode: BodyWriteMode,
 ) -> eyre::Result<()> {
@@ -264,7 +264,7 @@ pub(crate) async fn write_h1_body(
 }
 
 pub(crate) async fn write_h1_body_chunk(
-    transport: &impl WriteOwned,
+    transport: &mut impl WriteOwned,
     chunk: Piece,
     mode: BodyWriteMode,
 ) -> eyre::Result<()> {
@@ -292,7 +292,7 @@ pub(crate) async fn write_h1_body_chunk(
 }
 
 pub(crate) async fn write_h1_body_end(
-    transport: &impl WriteOwned,
+    transport: &mut impl WriteOwned,
     mode: BodyWriteMode,
 ) -> eyre::Result<()> {
     debug!(?mode, "writing h1 body end");

--- a/crates/hring/src/h1/body.rs
+++ b/crates/hring/src/h1/body.rs
@@ -87,9 +87,9 @@ impl<T: ReadOwned> Body for H1Body<T> {
         }
 
         match &mut self.state {
-            Decoder::Chunked(state) => state.next_chunk(&mut self.buf, &self.transport_r).await,
+            Decoder::Chunked(state) => state.next_chunk(&mut self.buf, &mut self.transport_r).await,
             Decoder::ContentLength(state) => {
-                state.next_chunk(&mut self.buf, &self.transport_r).await
+                state.next_chunk(&mut self.buf, &mut self.transport_r).await
             }
         }
     }
@@ -106,7 +106,7 @@ impl ContentLengthDecoder {
     async fn next_chunk(
         &mut self,
         buf_slot: &mut Option<RollMut>,
-        transport: &impl ReadOwned,
+        transport: &mut impl ReadOwned,
     ) -> eyre::Result<BodyChunk> {
         let remain = self.len - self.read;
         if remain == 0 {
@@ -144,7 +144,7 @@ impl ChunkedDecoder {
     async fn next_chunk(
         &mut self,
         buf_slot: &mut Option<RollMut>,
-        transport: &impl ReadOwned,
+        transport: &mut impl ReadOwned,
     ) -> eyre::Result<BodyChunk> {
         loop {
             let mut buf = buf_slot

--- a/crates/hring/src/h1/client.rs
+++ b/crates/hring/src/h1/client.rs
@@ -28,7 +28,7 @@ pub trait ClientDriver {
 /// The transport halves will be returned unless the server requested connection
 /// close or the request body wasn't fully drained
 pub async fn request<R, W, D>(
-    (transport_r, transport_w): (R, W),
+    (mut transport_r, transport_w): (R, W),
     mut req: Request,
     body: &mut impl Body,
     driver: D,
@@ -81,7 +81,7 @@ where
         async move {
             let (buf, res) = read_and_parse(
                 super::parse::response,
-                &transport_r,
+                &mut transport_r,
                 buf,
                 // TODO: make this configurable
                 64 * 1024,

--- a/crates/hring/src/h1/client.rs
+++ b/crates/hring/src/h1/client.rs
@@ -28,7 +28,7 @@ pub trait ClientDriver {
 /// The transport halves will be returned unless the server requested connection
 /// close or the request body wasn't fully drained
 pub async fn request<R, W, D>(
-    (mut transport_r, transport_w): (R, W),
+    (mut transport_r, mut transport_w): (R, W),
     mut req: Request,
     body: &mut impl Body,
     driver: D,
@@ -63,7 +63,7 @@ where
 
     let send_body_fut = {
         async move {
-            match write_h1_body(&transport_w, body, mode).await {
+            match write_h1_body(&mut transport_w, body, mode).await {
                 Err(err) => {
                     // TODO: find way to report this error to the driver without
                     // spawning, without ref-counting the driver, etc.

--- a/crates/hring/src/h1/encode.rs
+++ b/crates/hring/src/h1/encode.rs
@@ -169,12 +169,12 @@ where
     // TODO: move `mode` into `H1Encoder`? we don't need it for h2
     async fn write_body_chunk(&mut self, chunk: Piece, mode: BodyWriteMode) -> eyre::Result<()> {
         // TODO: inline
-        write_h1_body_chunk(&self.transport_w, chunk, mode).await
+        write_h1_body_chunk(&mut self.transport_w, chunk, mode).await
     }
 
     async fn write_body_end(&mut self, mode: BodyWriteMode) -> eyre::Result<()> {
         // TODO: inline
-        write_h1_body_end(&self.transport_w, mode).await
+        write_h1_body_end(&mut self.transport_w, mode).await
     }
 
     async fn write_trailers(&mut self, trailers: Box<Headers>) -> eyre::Result<()> {

--- a/crates/hring/src/h1/server.rs
+++ b/crates/hring/src/h1/server.rs
@@ -52,7 +52,7 @@ pub async fn serve(
         let req;
         (client_buf, req) = match read_and_parse(
             super::parse::request,
-            &transport_r,
+            &mut transport_r,
             client_buf,
             conf.max_http_header_len,
         )

--- a/crates/hring/src/h2/server.rs
+++ b/crates/hring/src/h2/server.rs
@@ -91,7 +91,7 @@ struct HeadersData {
 }
 
 pub async fn serve(
-    (mut transport_r, transport_w): (impl ReadOwned, impl WriteOwned),
+    (mut transport_r, mut transport_w): (impl ReadOwned, impl WriteOwned),
     conf: Rc<ServerConf>,
     mut client_buf: RollMut,
     driver: Rc<impl ServerDriver + 'static>,
@@ -721,7 +721,7 @@ async fn send_goaway(
 
 async fn h2_write_loop(
     mut ev_rx: mpsc::Receiver<H2ConnEvent>,
-    transport_w: impl WriteOwned,
+    mut transport_w: impl WriteOwned,
     mut out_scratch: RollMut,
 ) -> eyre::Result<()> {
     let mut hpack_enc = hring_hpack::Encoder::new();

--- a/crates/hring/src/util.rs
+++ b/crates/hring/src/util.rs
@@ -8,7 +8,7 @@ use hring_buffet::{ReadOwned, Roll, RollMut};
 /// Returns `None` on EOF, error if partially parsed message.
 pub(crate) async fn read_and_parse<Parser, Output>(
     parser: Parser,
-    stream: &impl ReadOwned,
+    stream: &mut impl ReadOwned,
     mut buf: RollMut,
     max_len: usize,
 ) -> eyre::Result<Option<(RollMut, Output)>>

--- a/crates/hring/tests/integration_test.rs
+++ b/crates/hring/tests/integration_test.rs
@@ -10,7 +10,7 @@ use hring::{
     h1, h2, Body, BodyChunk, Encoder, ExpectResponseHeaders, Headers, HeadersExt, Method, Request,
     Responder, Response, ResponseDone, ServerDriver,
 };
-use hring_buffet::{ChanRead, ChanWrite, Piece, RollMut, SplitOwned};
+use hring_buffet::{ChanRead, ChanWrite, IntoSplit, Piece, RollMut};
 use http::{header, StatusCode};
 use httparse::{Status, EMPTY_HEADER};
 use pretty_assertions::assert_eq;
@@ -747,7 +747,7 @@ fn curl_echo_body_noproxy(typ: BodyType) {
                         tokio_uring::spawn(async move {
                             let driver = TestDriver;
                             h1::serve(
-                                transport.split_owned(),
+                                transport.into_split(),
                                 conf,
                                 RollMut::alloc().unwrap(),
                                 driver,
@@ -918,7 +918,7 @@ fn h2_basic_post() {
 
                         tokio_uring::spawn(async move {
                             h2::serve(
-                                transport.split_owned(),
+                                transport.into_split(),
                                 conf,
                                 RollMut::alloc().unwrap(),
                                 driver,
@@ -1105,7 +1105,7 @@ fn h2_basic_get() {
 
                         tokio_uring::spawn(async move {
                             h2::serve(
-                                transport.split_owned(),
+                                transport.into_split(),
                                 conf,
                                 RollMut::alloc().unwrap(),
                                 driver,

--- a/crates/hring/tests/proxy.rs
+++ b/crates/hring/tests/proxy.rs
@@ -7,13 +7,12 @@ use hring::{
     h1, Body, BodyChunk, Encoder, ExpectResponseHeaders, HeadersExt, Responder, Response,
     ResponseDone, ServerDriver,
 };
-use hring_buffet::{RollMut, SplitOwned};
+use hring_buffet::{RollMut, SplitOwned, TcpReadHalf, TcpWriteHalf};
 use http::StatusCode;
 use std::{cell::RefCell, future::Future, net::SocketAddr, rc::Rc};
-use tokio_uring::net::TcpStream;
 use tracing::debug;
 
-pub type TransportPool = Rc<RefCell<Vec<Rc<TcpStream>>>>;
+pub type TransportPool = Rc<RefCell<Vec<(TcpReadHalf, TcpWriteHalf)>>>;
 
 pub struct ProxyDriver {
     pub upstream_addr: SocketAddr,
@@ -46,24 +45,20 @@ impl ServerDriver for ProxyDriver {
             transport
         } else {
             debug!("making new connection to upstream!");
-            Rc::new(tokio_uring::net::TcpStream::connect(self.upstream_addr).await?)
+            tokio_uring::net::TcpStream::connect(self.upstream_addr)
+                .await?
+                .split_owned()
         };
 
         let driver = ProxyClientDriver { respond };
 
-        let (transport, res) = h1::request(
-            (transport.clone(), transport.clone()),
-            req,
-            req_body,
-            driver,
-        )
-        .await?;
+        let (transport, res) = h1::request(transport, req, req_body, driver).await?;
 
         if let Some(transport) = transport {
             let mut pool = self.pool.borrow_mut();
             // FIXME: leaky abstraction, `h1::request` returns both halves of the
             // transport, which are both actually `Rc<TcpStream>`
-            pool.push(transport.0);
+            pool.push(transport);
         }
 
         Ok(res)

--- a/crates/hring/tests/proxy.rs
+++ b/crates/hring/tests/proxy.rs
@@ -7,7 +7,7 @@ use hring::{
     h1, Body, BodyChunk, Encoder, ExpectResponseHeaders, HeadersExt, Responder, Response,
     ResponseDone, ServerDriver,
 };
-use hring_buffet::{RollMut, SplitOwned, TcpReadHalf, TcpWriteHalf};
+use hring_buffet::{IntoSplit, RollMut, TcpReadHalf, TcpWriteHalf};
 use http::StatusCode;
 use std::{cell::RefCell, future::Future, net::SocketAddr, rc::Rc};
 use tracing::debug;
@@ -47,7 +47,7 @@ impl ServerDriver for ProxyDriver {
             debug!("making new connection to upstream!");
             tokio_uring::net::TcpStream::connect(self.upstream_addr)
                 .await?
-                .split_owned()
+                .into_split()
         };
 
         let driver = ProxyClientDriver { respond };
@@ -154,7 +154,7 @@ pub async fn start(
                             pool,
                         };
                         h1::serve(
-                            transport.split_owned(),
+                            transport.into_split(),
                             conf,
                             RollMut::alloc().unwrap(),
                             driver,

--- a/test-crates/hring-h2spec/src/non_uring.rs
+++ b/test-crates/hring-h2spec/src/non_uring.rs
@@ -8,7 +8,7 @@ use crate::SDriver;
 pub(crate) async fn spawn_server(addr: SocketAddr) -> color_eyre::Result<SocketAddr> {
     let ln = TcpListener::bind(addr).await?;
     let addr = ln.local_addr()?;
-    tracing::info!("Listening on {}", ln.local_addr()?);
+    tracing::info!("Listening (without io-uring) on {}", ln.local_addr()?);
 
     let _task = tokio::task::spawn_local(async move { run_server(ln).await.unwrap() });
 


### PR DESCRIPTION
Still prep work for #93 - this allows eschewing `RefCell` for the non-uring codepaths.