### PR TITLE
Allow running h2spec without io-uring

### DIFF
--- a/crates/hring-buffet/Cargo.toml
+++ b/crates/hring-buffet/Cargo.toml
@@ -13,9 +13,8 @@ Buffer management for the `hring` crate.
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["non-uring"]
+default = ["tokio-uring"]
 miri = []
-non-uring = ["tokio/net", "tokio/rt"]
 
 [dependencies]
 eyre = "0.6.8"
@@ -26,7 +25,7 @@ nom = "7.1.3"
 pretty-hex = "0.3.0"
 thiserror = { version = "1.0.38", default-features = false }
 tokio = { version = "1.25.0", features = ["sync", "macros"] }
-tokio-uring = "0.4.0"
+tokio-uring = { version = "0.4.0", optional = true }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/crates/hring/Cargo.toml
+++ b/crates/hring/Cargo.toml
@@ -10,6 +10,11 @@ description = """
 An HTTP implementation on top of io_uring
 """
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+default = ["tokio-uring"]
+
 [dependencies]
 byteorder = "1.4.3"
 enum-repr = "0.2.6"
@@ -25,7 +30,7 @@ pretty-hex = { version = "0.3.0", default-features = false }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "const_new", "union"] }
 thiserror = { version = "1.0.38", default-features = false }
 tokio = { version = "1.24.2", features = ["macros", "sync"] }
-tokio-uring = "0.4.0"
+tokio-uring = { version = "0.4.0", optional = true }
 tracing = { version = "0.1.37", default-features = false }
 
 [dev-dependencies]
@@ -38,6 +43,3 @@ tokio = { version = "1.24.2", default-features = false, features = ["io-util", "
 futures-util = { version = "0.3.25", default-features = false, features = ["std"] }
 curl = { version = "0.4.44", default-features = false, features = ["http2"] }
 libc = "0.2.139"
-
-[features]
-non-uring = []

--- a/crates/hring/src/h2/encode.rs
+++ b/crates/hring/src/h2/encode.rs
@@ -138,7 +138,7 @@ impl Drop for H2Encoder {
 
         if !evs.is_empty() {
             let tx = self.tx.clone();
-            tokio_uring::spawn(async move {
+            crate::spawn(async move {
                 for ev in evs {
                     if tx.send(ev).await.is_err() {
                         warn!("could not send event to h2 connection handler");

--- a/crates/hring/src/h2/server.rs
+++ b/crates/hring/src/h2/server.rs
@@ -1021,7 +1021,7 @@ fn end_headers(
                 rx: piece_rx,
             };
 
-            tokio_uring::spawn({
+            crate::spawn({
                 let driver = driver.clone();
                 async move {
                     let mut req_body = req_body;

--- a/test-crates/hring-h2spec/Cargo.toml
+++ b/test-crates/hring-h2spec/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+hring = { version = "0.1.0", path = "../../crates/hring", default-features = false }
 color-eyre = "0.6.2"
-hring = { version = "0.1.0", path = "../../crates/hring" }
 tokio = { version = "1.23.0", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
@@ -17,5 +17,5 @@ which = "4.4.0"
 opt-level = 2
 
 [features]
-# default = ["non-uring"]
-non-uring = ["hring/non-uring"]
+default = ["tokio-uring"]
+tokio-uring = ["hring/tokio-uring"]

--- a/test-crates/hring-h2spec/src/non_uring.rs
+++ b/test-crates/hring-h2spec/src/non_uring.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, rc::Rc};
 
-use hring::buffet::{RollMut, SplitOwned};
+use hring::buffet::RollMut;
 use tokio::net::TcpListener;
 
 use crate::SDriver;
@@ -24,7 +24,7 @@ pub(crate) async fn run_server(ln: TcpListener) -> color_eyre::Result<()> {
         let driver = Rc::new(SDriver);
 
         tokio::task::spawn_local(async move {
-            if let Err(e) = hring::h2::serve(stream.split_owned(), conf, client_buf, driver).await {
+            if let Err(e) = hring::h2::serve(stream.into_split(), conf, client_buf, driver).await {
                 tracing::error!("error serving client {}: {}", addr, e);
             }
         });


### PR DESCRIPTION
"cargo run --no-default-features" now works. We can't yet pull tokio-uring only on non-Linux platforms but... we'll get there at some point?

Closes #93