### PR TITLE
bump to nightly-2023-03-07

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-02-20"
+channel = "nightly-2023-03-07"
 components = ["llvm-tools-preview"]


### PR DESCRIPTION
Among other things, "sparse" is the default as of 5 days ago, which might help in CI: https://github.com/rust-lang/cargo/pull/11791