### PR TITLE
Exclude test crates & samples from code coverage report

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  # note: maybe `maybe-uring` should be excluded too, we don't
+  # test the non-uring codepath on linux, where coverage is measured.
+  - "test-crates/**"
+  - "crates/hring-bingo-ktls/**"


### PR DESCRIPTION
They're driving down code coverage artificially - we care about the core crates being tested, not the rest.